### PR TITLE
all_tcp flag, query master on notifies

### DIFF
--- a/slappy.conf.sample
+++ b/slappy.conf.sample
@@ -6,3 +6,4 @@ zone_path = ./
 log = slappy.log
 bind_address = 127.0.0.1
 bind_port = 5358
+all_tcp = true


### PR DESCRIPTION
- `all_tcp` flag ensure that we can send all traffic via tcp, so that it'll
traverse a proxy
- Adds step to query the master for the serial number on an update so we
dont' do unnecessary zonefile writes/rndc reloads
- Makes `check_serial` more generic
- Reorders config flags for cleanliness