### PR TITLE
Log some stats on a Signal

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,6 +12,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"runtime"
 	"strings"
 	"syscall"
 	"time"
@@ -430,15 +431,19 @@ func serve(net, ip, port string) {
 }
 
 func listen() {
-	sig := make(chan os.Signal)
-	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+	siq_quit := make(chan os.Signal)
+	signal.Notify(siq_quit, syscall.SIGINT, syscall.SIGTERM)
+	sig_stat := make(chan os.Signal)
+	signal.Notify(sig_stat, syscall.SIGUSR1)
 
 forever:
 	for {
 		select {
-		case s := <-sig:
+		case s := <-siq_quit:
 			logger.Info(fmt.Sprintf("Signal (%d) received, stopping", s))
 			break forever
+		case _ = <-sig_stat:
+			logger.Info(fmt.Sprintf("Goroutines: %d", runtime.NumGoroutine()))
 		}
 	}
 }


### PR DESCRIPTION
This triggers a log of stats (currently just #goroutines) when it gets
a USR1 (signal designated for users):
```
$ ps aux | grep slappy
timo6371        92217 ./slappy -config slappy.conf
$ kill -USR1 92217
....#slappy.log
INFO : 2015/09/29 13:50:10 main.go:465: # Goroutines: 11
```

Could be useful later.