### PR TITLE
Use a Config struct to encapsulate config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,0 +1,129 @@
+package config
+
+import (
+	"flag"
+	"fmt"
+	"github.com/rackerlabs/iniflags"
+	"net"
+	"strings"
+	"time"
+
+	"github.com/rackerlabs/slappy/log"
+
+)
+
+var conf Config;
+
+type Config struct {
+	Debug           bool
+	Logfile         string
+	Logger          log.Log
+	Bind_address    string
+	Bind_port       string
+	All_tcp         bool
+	Master          string
+	Query_dest      string
+	Zone_file_path  string
+	Query_timeout   time.Duration
+	Transfer_source *net.TCPAddr
+	Allow_notify    []string
+	Limit_rndc      bool
+	Rndc_timeout    time.Duration
+	Rndc_limit      int
+	Rndc_counter    chan string
+}
+
+// These vars are necessary because the actual values in the `flag.x` don't
+// get populated until you call iniflags.Parse() and these require additional processing
+var (
+	transfer_source *net.TCPAddr
+	rndc_counter    chan string
+)
+
+func Setup_config() {
+	// Load config
+	debug := flag.Bool("debug", false, "enables debug mode")
+	logfile := flag.String("log", "", "file for the log, if empty will log only to stdout")
+
+	bind_address := flag.String("bind_address", "", "IP to listen on")
+	bind_port := flag.String("bind_port", "5358", "port to listen on")
+	all_tcp := flag.Bool("all_tcp", true, "sends all queries over tcp")
+
+	master := flag.String("master", "", "master to zone transfer from")
+	query_dest := flag.String("queries", "", "nameserver to query to grok zone state")
+	zone_file_path := flag.String("zone_path", "", "path to write zone files")
+	query_timeout_raw := flag.Int("query_timeout", 10, "seconds before output dns queries timeout from slappy")
+
+	transfer_source_raw := flag.String("transfer_source", "", "source IP for zone transfers")
+	transfer_source = nil
+	allow_notify_raw := flag.String("allow_notify", "", "comma-separated list of IPs allowed to query slappy")
+	allow_notify := []string{}
+
+	limit_rndc := flag.Bool("limit_rndc", false, "enables limiting concurrent rndc calls with rndc_timeout, rndc_limit")
+	rndc_timeout_raw := flag.Int("rndc_timeout", 25, "seconds before waiting rndc call will abort")
+	rndc_limit := flag.Int("rndc_limit", 50, "number of concurrent rndc calls allowed if limit_rndc=true")
+
+	flag.Usage = func() {
+		flag.PrintDefaults()
+	}
+	// You can specify an .ini file with the -config
+	iniflags.Parse()
+
+	// Parse the transfer_source IP into the proper type
+	if *transfer_source_raw != "" {
+		transfer_source = &net.TCPAddr{IP: net.ParseIP(*transfer_source_raw)}
+	}
+	if *allow_notify_raw != "" {
+		for _, ip := range strings.Split((*allow_notify_raw), ",") {
+			allow_notify = append(allow_notify, strings.TrimSpace(ip))
+		}
+	}
+	query_timeout := time.Duration(*query_timeout_raw) * time.Second
+	rndc_timeout := time.Duration(*rndc_timeout_raw) * time.Second
+
+	// Set up rndc rate limiter
+	if *limit_rndc == true { rndc_counter = make(chan string, *rndc_limit) }
+
+	conf = Config{
+		Debug: *debug,
+		Logfile: *logfile,
+		Bind_address: *bind_address,
+		Bind_port: *bind_port,
+		All_tcp: *all_tcp,
+		Master: *master,
+		Query_dest: *query_dest,
+		Zone_file_path: *zone_file_path,
+		Query_timeout: query_timeout,
+		Transfer_source: transfer_source,
+		Allow_notify: allow_notify,
+		Limit_rndc: *limit_rndc,
+		Rndc_timeout: rndc_timeout,
+		Rndc_limit: *rndc_limit,
+		Rndc_counter: rndc_counter,
+	}
+}
+
+func (c *Config) Print(logger log.Log) {
+	logger.Debug("****************CONFIG****************")
+	logger.Debug(fmt.Sprintf("debug = %t", c.Debug))
+	logger.Debug(fmt.Sprintf("log = %s", c.Logfile))
+	logger.Debug(fmt.Sprintf("bind_address = %s", c.Bind_address))
+	logger.Debug(fmt.Sprintf("bind_port = %s", c.Bind_port))
+	logger.Debug(fmt.Sprintf("all_tcp = %t", c.All_tcp))
+	logger.Debug(fmt.Sprintf("master = %s", c.Master))
+	logger.Debug(fmt.Sprintf("query_dest = %s", c.Query_dest))
+	logger.Debug(fmt.Sprintf("zone_file_path = %s", c.Zone_file_path))
+	logger.Debug(fmt.Sprintf("query_timeout = %s", c.Query_timeout))
+	logger.Debug(fmt.Sprintf("limit_rndc = %t", c.Limit_rndc))
+	logger.Debug(fmt.Sprintf("rndc_timeout = %s", c.Rndc_timeout))
+	logger.Debug(fmt.Sprintf("rndc_limit = %d", c.Rndc_limit))
+	if c.Transfer_source != nil {
+		logger.Debug(fmt.Sprintf("transfer_source = %s", (c.Transfer_source).String()))
+	}
+	logger.Debug(fmt.Sprintf("allow_notify = %s", c.Allow_notify))
+	logger.Debug("****************CONFIG****************")
+}
+
+func Conf() Config {
+	return conf
+}

--- a/main.go
+++ b/main.go
@@ -2,10 +2,8 @@ package main
 
 import (
 	"errors"
-	"flag"
 	"fmt"
 	"github.com/rackerlabs/dns"
-	"github.com/rackerlabs/iniflags"
 	"net"
 	"os"
 	"os/exec"
@@ -15,26 +13,12 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/rackerlabs/slappy/config"
 	"github.com/rackerlabs/slappy/log"
 )
 
 var (
-	debug           *bool
-	logfile         *string
 	logger          log.Log
-	bind_address    *string
-	bind_port       *string
-	all_tcp         *bool
-	master          *string
-	query_dest      *string
-	zone_file_path  *string
-	query_timeout   time.Duration
-	transfer_source *net.TCPAddr
-	allow_notify    []string
-	limit_rndc      *bool
-	rndc_timeout    time.Duration
-	rndc_limit       *int
-	rndc_counter    chan string
 )
 
 // Command and Control OPCODE
@@ -122,9 +106,11 @@ func handle_error(message *dns.Msg, writer dns.ResponseWriter, op string) *dns.M
 }
 
 func handle_create(question dns.Question, message *dns.Msg, writer dns.ResponseWriter) *dns.Msg {
+	conf := config.Conf()
+
 	zone_name := question.Name
 
-	serial := get_serial(zone_name, *query_dest)
+	serial := get_serial(zone_name, conf.Query_dest)
 	if serial != 0 {
 		logger.Info(fmt.Sprintf("CREATE SUCCESS %s : zone already exists", zone_name))
 		return message
@@ -137,7 +123,7 @@ func handle_create(question dns.Question, message *dns.Msg, writer dns.ResponseW
 		return handle_error(message, writer, "SERVFAIL")
 	}
 
-	output_path := *zone_file_path + zone_name + "zone"
+	output_path := conf.Zone_file_path + zone_name + "zone"
 
 	err = write_zonefile(zone_name, zone, output_path)
 	if err != nil {
@@ -158,16 +144,18 @@ func handle_create(question dns.Question, message *dns.Msg, writer dns.ResponseW
 }
 
 func handle_notify(question dns.Question, message *dns.Msg, writer dns.ResponseWriter) *dns.Msg {
+	conf := config.Conf()
+
 	zone_name := question.Name
 
-	serial := get_serial(zone_name, *query_dest)
+	serial := get_serial(zone_name, conf.Query_dest)
 	if serial == 0 {
 		logger.Error(fmt.Sprintf("UPDATE ERROR %s : zone doesn't exist", zone_name))
 		return handle_error(message, writer, "SERVFAIL")
 	}
 
 	// Check our master for the SOA of this zone
-	master_serial := get_serial(zone_name, *master)
+	master_serial := get_serial(zone_name, conf.Master)
 	if master_serial == 0 {
 		logger.Error(fmt.Sprintf("UPDATE ERROR %s : problem with master SOA query", zone_name))
 		return handle_error(message, writer, "SERVFAIL")
@@ -183,7 +171,7 @@ func handle_notify(question dns.Question, message *dns.Msg, writer dns.ResponseW
 		return handle_error(message, writer, "SERVFAIL")
 	}
 
-	output_path := *zone_file_path + zone_name + "zone"
+	output_path := conf.Zone_file_path + zone_name + "zone"
 
 	err = write_zonefile(zone_name, zone, output_path)
 	if err != nil {
@@ -204,9 +192,10 @@ func handle_notify(question dns.Question, message *dns.Msg, writer dns.ResponseW
 }
 
 func handle_delete(question dns.Question, message *dns.Msg, writer dns.ResponseWriter) *dns.Msg {
+	conf := config.Conf()
 	zone_name := question.Name
 
-	serial := get_serial(zone_name, *query_dest)
+	serial := get_serial(zone_name, conf.Query_dest)
 	if serial == 0 {
 		logger.Info(fmt.Sprintf("DELETE SUCCESS %s : zone doesn't exist", zone_name))
 		return message
@@ -226,6 +215,8 @@ func handle_delete(question dns.Question, message *dns.Msg, writer dns.ResponseW
 }
 
 func rndc(op, zone_name, output_path string) error {
+	conf := config.Conf()
+
 	cmd := "rndc"
 	zone_clause := ""
 	args := []string{}
@@ -243,7 +234,7 @@ func rndc(op, zone_name, output_path string) error {
 		return errors.New("Invalid RNDC command")
 	}
 
-	if *limit_rndc == false {
+	if conf.Limit_rndc == false {
 		if e := exec.Command(cmd, args...).Run(); e != nil {
 			return err
 		}
@@ -264,14 +255,14 @@ func rndc(op, zone_name, output_path string) error {
 		// spawn a new Goroutine, this immediately jumps down to the select statement after the
 		// function call and starts waiting on the timeout, or the ack that the call finished
 		go func() {
-			// Goroutine will wait until it can write to the 'rndc_counter'
-			rndc_counter <- "rndc"
+			// Goroutine will wait until it can write to the 'conf.Rndc_counter'
+			conf.Rndc_counter <- "rndc"
 			// If it took longer than the timeout to write, we will have a message waiting in interrupt
 			select {
 			case _ = <-interrupt:
-				// If there's an interrupt, we ack rndc_counter and break out without execing our rndc call
+				// If there's an interrupt, we ack conf.Rndc_counter and break out without execing our rndc call
 				go func() {
-					<-rndc_counter
+					<-conf.Rndc_counter
 					// do a debug log to say timeout
 					logger.Error("ERROR RNDC: "+rndc_string+" wasn't executed before timeout")
 				}()
@@ -286,8 +277,8 @@ func rndc(op, zone_name, output_path string) error {
 			}
 
 			go func() {
-				<-rndc_counter
-				// We ack rndc_counter once so that another query can have the lock
+				<-conf.Rndc_counter
+				// We ack conf.Rndc_counter once so that another query can have the lock
 				logger.Debug("RNDC SUCCESS: "+rndc_string+" completed")
 			}()
 			// Since we've finished, we light up the finished channel, so the main function knows
@@ -298,7 +289,7 @@ func rndc(op, zone_name, output_path string) error {
 		select {
 		case _ = <-finished:
 			// We finished before the timeout
-		case <-time.After(rndc_timeout):
+		case <-time.After(conf.Rndc_timeout):
 			// We have timed out, throw away the rndc call by interupting the goroutine above
 			// Spawn a GoRoutine for the interrupt so that we can return this function
 			// There's a small amount of time between realizing the timeout, and before this
@@ -313,22 +304,24 @@ func rndc(op, zone_name, output_path string) error {
 }
 
 func do_axfr(zone_name string) ([]dns.RR, error) {
+	conf := config.Conf()
+
 	result := []dns.RR{}
 	message := new(dns.Msg)
 	message.SetAxfr(zone_name)
-	transfer := &dns.Transfer{DialTimeout: query_timeout, ReadTimeout: query_timeout}
-	if transfer_source != nil {
-		d := net.Dialer{LocalAddr: transfer_source}
-		c, err := d.Dial("tcp", *master)
+	transfer := &dns.Transfer{DialTimeout: conf.Query_timeout, ReadTimeout: conf.Query_timeout}
+	if conf.Transfer_source != nil {
+		d := net.Dialer{LocalAddr: conf.Transfer_source}
+		c, err := d.Dial("tcp", conf.Master)
 		if err != nil {
 			logger.Debug("AXFR ERROR : problem dialing master")
 			return result, err
 		}
 		dnscon := &dns.Conn{Conn: c}
-		transfer = &dns.Transfer{Conn: dnscon, DialTimeout: query_timeout, ReadTimeout: query_timeout}
+		transfer = &dns.Transfer{Conn: dnscon, DialTimeout: conf.Query_timeout, ReadTimeout: conf.Query_timeout}
 	}
 
-	channel, err := transfer.In(message, *master)
+	channel, err := transfer.In(message, conf.Master)
 	if err != nil {
 		return result, err
 	}
@@ -340,14 +333,16 @@ func do_axfr(zone_name string) ([]dns.RR, error) {
 }
 
 func get_serial(zone_name, query_dest string) uint32 {
+	conf := config.Conf()
+
 	var serial uint32 = 0
 	var in *dns.Msg;
 
 	m := new(dns.Msg)
 	m.SetQuestion(zone_name, dns.TypeSOA)
 
-	if transfer_source != nil {
-		d := net.Dialer{LocalAddr: transfer_source}
+	if conf.Transfer_source != nil {
+		d := net.Dialer{LocalAddr: conf.Transfer_source}
 		c, err := d.Dial("tcp", query_dest)
 		if err != nil {
 			logger.Debug(fmt.Sprintf("QUERY ERROR : problem dialing query_dest %s", query_dest))
@@ -362,8 +357,8 @@ func get_serial(zone_name, query_dest string) uint32 {
 		}
 		co.Close()
 	} else {
-		c := &dns.Client{DialTimeout: query_timeout, ReadTimeout: query_timeout}
-		if *all_tcp == true { c.Net = "tcp" }
+		c := &dns.Client{DialTimeout: conf.Query_timeout, ReadTimeout: conf.Query_timeout}
+		if conf.All_tcp == true { c.Net = "tcp" }
 		// _ is query time, might be useful later
 		var err error;
 		in, _, err = c.Exchange(m, query_dest)
@@ -408,10 +403,12 @@ func write_zonefile(zone_name string, rrs []dns.RR, output_path string) error {
 }
 
 func allowed(notifier string) bool {
-	if len(allow_notify) == 0 {
+	conf := config.Conf()
+
+	if len(conf.Allow_notify) == 0 {
 		return true
 	}
-	for _, ip := range allow_notify {
+	for _, ip := range conf.Allow_notify {
 		if notifier == ip {
 			return true
 		}
@@ -460,77 +457,20 @@ func debug_request(request dns.Msg, question dns.Question, writer dns.ResponseWr
 	return strings.Join(s, "")
 }
 
-func debug_config() {
-	logger.Debug("****************CONFIG****************")
-	logger.Debug(fmt.Sprintf("debug = %t", *debug))
-	logger.Debug(fmt.Sprintf("log = %s", *logfile))
-	logger.Debug(fmt.Sprintf("bind_address = %s", *bind_address))
-	logger.Debug(fmt.Sprintf("bind_port = %s", *bind_port))
-	logger.Debug(fmt.Sprintf("all_tcp = %t", *all_tcp))
-	logger.Debug(fmt.Sprintf("master = %s", *master))
-	logger.Debug(fmt.Sprintf("query_dest = %s", *query_dest))
-	logger.Debug(fmt.Sprintf("zone_file_path = %s", *zone_file_path))
-	logger.Debug(fmt.Sprintf("query_timeout = %s", query_timeout))
-	logger.Debug(fmt.Sprintf("limit_rndc = %t", *limit_rndc))
-	logger.Debug(fmt.Sprintf("rndc_timeout = %s", rndc_timeout))
-	logger.Debug(fmt.Sprintf("rndc_limit = %d", *rndc_limit))
-	if transfer_source != nil {
-		logger.Debug(fmt.Sprintf("transfer_source = %s", (*transfer_source).String()))
-	}
-	logger.Debug(fmt.Sprintf("allow_notify = %s", allow_notify))
-	logger.Debug("****************CONFIG****************")
-}
 
 func main() {
-	// Load config
-	debug = flag.Bool("debug", false, "enables debug mode")
-	logfile = flag.String("log", "", "file for the log, if empty will log only to stdout")
-
-	bind_address = flag.String("bind_address", "", "IP to listen on")
-	bind_port = flag.String("bind_port", "5358", "port to listen on")
-	all_tcp = flag.Bool("all_tcp", true, "sends all queries over tcp")
-
-	master = flag.String("master", "", "master to zone transfer from")
-	query_dest = flag.String("queries", "", "nameserver to query to grok zone state")
-	zone_file_path = flag.String("zone_path", "", "path to write zone files")
-	query_timeout_raw := flag.Int("query_timeout", 10, "seconds before output dns queries timeout from slappy")
-
-	transfer_source_raw := flag.String("transfer_source", "", "source IP for zone transfers")
-	transfer_source = nil
-	allow_notify_raw := flag.String("allow_notify", "", "comma-separated list of IPs allowed to query slappy")
-	allow_notify = []string{}
-
-	limit_rndc = flag.Bool("limit_rndc", false, "enables limiting concurrent rndc calls with rndc_timeout, rndc_limit")
-	rndc_timeout_raw := flag.Int("rndc_timeout", 25, "seconds before waiting rndc call will abort")
-	rndc_limit = flag.Int("rndc_limit", 50, "number of concurrent rndc calls allowed if limit_rndc=true")
-
-	flag.Usage = func() {
-		flag.PrintDefaults()
-	}
-	// You can specify an .ini file with the -config
-	iniflags.Parse()
-
-	// Parse the transfer_source IP into the proper type
-	if *transfer_source_raw != "" {
-		transfer_source = &net.TCPAddr{IP: net.ParseIP(*transfer_source_raw)}
-	}
-	if *allow_notify_raw != "" {
-		for _, ip := range strings.Split((*allow_notify_raw), ",") {
-			allow_notify = append(allow_notify, strings.TrimSpace(ip))
-		}
-	}
-	query_timeout = time.Duration(*query_timeout_raw) * time.Second
-	rndc_timeout = time.Duration(*rndc_timeout_raw) * time.Second
-
-	// Set up rndc rate limiter
-	if *limit_rndc == true { rndc_counter = make(chan string, *rndc_limit) }
+	// Set up config
+	config.Setup_config()
+	conf := config.Conf()
 
 	// Set up logging
-	logger = log.InitLog(*logfile, *debug)
-	debug_config()
+	logger = log.InitLog(conf.Logfile, conf.Debug)
 
-	go serve("tcp", *bind_address, *bind_port)
-	go serve("udp", *bind_address, *bind_port)
+	// Debug config
+	conf.Print(logger)
+
+	go serve("tcp", conf.Bind_address, conf.Bind_port)
+	go serve("udp", conf.Bind_address, conf.Bind_port)
 
 	listen()
 }


### PR DESCRIPTION
This refactoring cleans out `main.go` of config parsing
and puts it in it's own module.