### PR TITLE
Stats via DNS

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -32,6 +32,7 @@ type Config struct {
 	Rndc_counter    chan string
 	Status_file     string
 	Status_interval time.Duration
+	Stats_uri       string
 }
 
 // These vars are necessary because the actual values in the `flag.x` don't
@@ -66,6 +67,8 @@ func Setup_config() {
 
 	status_file := flag.String("status_file", "", "path to write a status file, empty means no status file")
 	status_interval_raw := flag.Int("status_interval", 60, "seconds to wait between status file writes")
+
+	stats_uri := flag.String("stats_uri", "/stats.", "hostname to dig for to get stats, should be an invalid dns name!")
 
 	flag.Usage = func() {
 		flag.PrintDefaults()
@@ -114,6 +117,7 @@ func Setup_config() {
 		Rndc_counter:    rndc_counter,
 		Status_file:     *status_file,
 		Status_interval: status_interval,
+		Stats_uri:       *stats_uri,
 	}
 }
 
@@ -133,7 +137,8 @@ func (c *Config) Print() {
 	logger.Debug(fmt.Sprintf("rndc_timeout = %s", c.Rndc_timeout))
 	logger.Debug(fmt.Sprintf("rndc_limit = %d", c.Rndc_limit))
 	logger.Debug(fmt.Sprintf("status_file = %s", c.Status_file))
-	logger.Debug(fmt.Sprintf("status_interval = %d", c.Status_interval))
+	logger.Debug(fmt.Sprintf("status_interval = %s", c.Status_interval))
+	logger.Debug(fmt.Sprintf("stats_uri = %s", c.Stats_uri))
 	if c.Transfer_source != nil {
 		logger.Debug(fmt.Sprintf("transfer_source = %s", (c.Transfer_source).String()))
 	}

--- a/stats/stats.go
+++ b/stats/stats.go
@@ -2,14 +2,27 @@ package stats
 
 import (
 	"fmt"
+	"github.com/rackerlabs/dns"
 	"io/ioutil"
+	"runtime"
 	"time"
 
 	"github.com/rackerlabs/slappy/config"
 	"github.com/rackerlabs/slappy/log"
 )
 
-func Status_file() {
+var (
+	starttime  time.Time
+	stats_chan chan string
+	queries    int
+	addzones   int
+	reloads    int
+	delzones   int
+	total_rndc int
+	rndc_att   int
+)
+
+func status_file() {
 	conf := config.Conf()
 	logger := log.Logger()
 
@@ -38,4 +51,76 @@ func Status_file() {
 func get_status() string {
 	// Figure out if we're in an error state
 	return "0"
+}
+
+func runtime_stats() []string {
+	rstats := []string{}
+
+	rstats = append(rstats, fmt.Sprintf("uptime: %.f", time.Now().Sub(starttime).Seconds()))
+	rstats = append(rstats, fmt.Sprintf("goroutines: %d", runtime.NumGoroutine()))
+
+	var mem runtime.MemStats
+	runtime.ReadMemStats(&mem)
+
+	rstats = append(rstats, fmt.Sprintf("memory: %.3fmb", float64(mem.Alloc)/1000000.0))
+	rstats = append(rstats, fmt.Sprintf("nextGC: %.3fmb", float64(mem.NextGC)/1000000.0))
+
+	rstats = append(rstats, fmt.Sprintf("queries: %d", queries))
+	rstats = append(rstats, fmt.Sprintf("addzones: %d", addzones))
+	rstats = append(rstats, fmt.Sprintf("reloads: %d", reloads))
+	rstats = append(rstats, fmt.Sprintf("delzones: %d", delzones))
+	rstats = append(rstats, fmt.Sprintf("rndc_attempts: %d", rndc_att))
+	rstats = append(rstats, fmt.Sprintf("rndc_success: %d", total_rndc))
+
+	return rstats
+}
+
+func Stats_dns_message(message *dns.Msg, writer dns.ResponseWriter) *dns.Msg {
+	conf := config.Conf()
+
+	for _, stat := range runtime_stats() {
+		txtRR := new(dns.TXT)
+		txtRR.Hdr = dns.RR_Header{Name: conf.Stats_uri, Rrtype: dns.TypeTXT, Class: dns.ClassINET, Ttl: 0}
+		txtRR.Txt = []string{stat}
+		message.Answer = append(message.Answer, txtRR)
+	}
+
+	return message
+}
+
+func Stat(stat string) {
+	stats_chan <- stat
+}
+
+func stats_listener() {
+	for {
+		select {
+		case event := <-stats_chan:
+			switch event {
+			case "query":
+				queries++
+			case "addzone":
+				addzones++
+				total_rndc++
+			case "delzone":
+				delzones++
+				total_rndc++
+			case "reload":
+				reloads++
+				total_rndc++
+			case "rndc_att":
+				rndc_att++
+			default:
+			}
+		default:
+			time.Sleep(20 * time.Millisecond)
+		}
+	}
+}
+
+func Init_stats() {
+	starttime = time.Now()
+	stats_chan = make(chan string, 1000)
+	go stats_listener()
+	go status_file()
 }


### PR DESCRIPTION
Yo dawg, I heard you like DNS, so I made you a REST API over DNS.

Not really, this exposes a hostname that no one would ever dig for (`/stats` by default)
that will return runtime statistics of slappy via TXT records in a DNS response.