### PR TITLE
Implement --version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ help:
 	@echo ""
 
 build: fmt
-	go build -o slappy main.go
+	go build -o slappy -ldflags "-X main.builddate=`date -u '+%Y-%m-%d_%I:%M:%S%p'` -X main.gitref=`git rev-parse HEAD`" main.go
 
 run:
 	./slappy -debug

--- a/config/config.go
+++ b/config/config.go
@@ -43,7 +43,7 @@ var (
 )
 
 func Setup_config() {
-	// Load config
+	// Load config, this should all be refactored because it's awful
 	debug := flag.Bool("debug", false, "enables debug mode")
 	logfile := flag.String("log", "", "file for the log, if empty will log only to stdout")
 

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"flag"
 	"fmt"
 	"github.com/rackerlabs/dns"
 	"os"
@@ -13,6 +14,9 @@ import (
 	"github.com/rackerlabs/slappy/slapdns"
 	"github.com/rackerlabs/slappy/stats"
 )
+
+var builddate = ""
+var gitref = ""
 
 func serve(net, ip, port string) {
 	logger := log.Logger()
@@ -50,9 +54,18 @@ forever:
 }
 
 func main() {
+	// Provide a '--version' flag
+	version := flag.Bool("version", false, "prints version information")
+
 	// Set up config
 	config.Setup_config()
 	conf := config.Conf()
+
+	// Exit if someone just wants to know version
+	if *version == true {
+		fmt.Println(fmt.Sprintf("built from %s on %s", gitref, builddate))
+		os.Exit(0)
+	}
 
 	// Set up logging
 	log.InitLog(conf.Logfile, conf.Debug)


### PR DESCRIPTION
Show a version string when `slappy --version` is run:

```
$ slappy --version
built from 0be26ee85a8cc591792acd55058ae912a339b77e on 2015-11-06_10:21:32PM
```