### PR TITLE
Optionally log to syslog

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -16,6 +16,7 @@ var conf Config
 type Config struct {
 	Debug           bool
 	Logfile         string
+	Log_syslog      bool
 	Logger          log.Log
 	Bind_address    string
 	Bind_port       string
@@ -46,6 +47,7 @@ func Setup_config() {
 	// Load config, this should all be refactored because it's awful
 	debug := flag.Bool("debug", false, "enables debug mode")
 	logfile := flag.String("log", "", "file for the log, if empty will log only to stdout")
+	log_syslog := flag.Bool("use_syslog", false, "log only to syslog")
 
 	bind_address := flag.String("bind_address", "", "IP to listen on")
 	bind_port := flag.String("bind_port", "5358", "port to listen on")
@@ -102,6 +104,7 @@ func Setup_config() {
 	conf = Config{
 		Debug:           *debug,
 		Logfile:         *logfile,
+		Log_syslog:      *log_syslog,
 		Bind_address:    *bind_address,
 		Bind_port:       *bind_port,
 		All_tcp:         *all_tcp,

--- a/log/log.go
+++ b/log/log.go
@@ -3,10 +3,41 @@ package log
 import (
 	"io"
 	"log"
+	"log/syslog"
 	"os"
 )
 
-var logger Log
+var logger SlapLogger
+
+type SlapLogger interface {
+	Debug(string)
+	Info(string)
+	Warn(string)
+	Error(string)
+}
+
+type SysLogger struct {
+	debug        bool
+	SyslogWriter *syslog.Writer
+}
+
+func (l *SysLogger) Debug(line string) {
+	if l.debug == true {
+		l.SyslogWriter.Debug("DEBUG: " + line)
+	}
+}
+
+func (l *SysLogger) Info(line string) {
+	l.SyslogWriter.Info("INFO : " + line)
+}
+
+func (l *SysLogger) Warn(line string) {
+	l.SyslogWriter.Warning("WARN : " + line)
+}
+
+func (l *SysLogger) Error(line string) {
+	l.SyslogWriter.Err("ERROR : " + line)
+}
 
 type Log struct {
 	debug       bool
@@ -34,23 +65,31 @@ func (l *Log) Error(line string) {
 	l.Errorlogger.Println(line)
 }
 
-func InitLog(logfile string, debug bool) {
-	var logwriter io.Writer = os.Stdout
-	if logfile != "" {
-		f, err := os.OpenFile(logfile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+func InitLog(log_syslog bool, logfile string, debug bool) {
+	if log_syslog == true {
+		slog, err := syslog.New(syslog.LOG_ALERT|syslog.LOG_LOCAL0, "slappy")
 		if err != nil {
 			panic(err)
 		}
-		logwriter = io.MultiWriter(f, os.Stdout)
-	}
+		logger = &SysLogger{debug: debug, SyslogWriter: slog}
+	} else {
+		var logwriter io.Writer = os.Stdout
+		if logfile != "" {
+			f, err := os.OpenFile(logfile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0666)
+			if err != nil {
+				panic(err)
+			}
+			logwriter = io.MultiWriter(f, os.Stdout)
+		}
 
-	d := log.New(logwriter, "DEBUG: ", log.Ldate|log.Ltime|log.Lmicroseconds|log.LUTC)
-	i := log.New(logwriter, "INFO : ", log.Ldate|log.Ltime|log.Lmicroseconds|log.LUTC)
-	c := log.New(logwriter, "WARN : ", log.Ldate|log.Ltime|log.Lmicroseconds|log.LUTC)
-	e := log.New(logwriter, "ERROR: ", log.Ldate|log.Ltime|log.Lmicroseconds|log.LUTC)
-	logger = Log{debug: debug, Debuglogger: *d, Infologger: *i, Warnlogger: *c, Errorlogger: *e}
+		d := log.New(logwriter, "DEBUG: ", log.Ldate|log.Ltime|log.Lmicroseconds|log.LUTC)
+		i := log.New(logwriter, "INFO : ", log.Ldate|log.Ltime|log.Lmicroseconds|log.LUTC)
+		c := log.New(logwriter, "WARN : ", log.Ldate|log.Ltime|log.Lmicroseconds|log.LUTC)
+		e := log.New(logwriter, "ERROR: ", log.Ldate|log.Ltime|log.Lmicroseconds|log.LUTC)
+		logger = &Log{debug: debug, Debuglogger: *d, Infologger: *i, Warnlogger: *c, Errorlogger: *e}
+	}
 }
 
-func Logger() Log {
+func Logger() SlapLogger {
 	return logger
 }

--- a/main.go
+++ b/main.go
@@ -68,7 +68,7 @@ func main() {
 	}
 
 	// Set up logging
-	log.InitLog(conf.Logfile, conf.Debug)
+	log.InitLog(conf.Log_syslog, conf.Logfile, conf.Debug)
 
 	// Debug config
 	conf.Print()

--- a/slappy.conf.sample
+++ b/slappy.conf.sample
@@ -4,6 +4,7 @@
 #################
 debug = false
 log = slappy.log
+use_syslog = false
 
 #################
 # Network Options


### PR DESCRIPTION
- Adds the ability via flag `use_syslog` in config to force logging
only to syslog via Go's `log/syslog` package.