### PR TITLE
Return rndc errors when rate limiting is off

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -36,7 +36,7 @@ func (l *SysLogger) Warn(line string) {
 }
 
 func (l *SysLogger) Error(line string) {
-	l.SyslogWriter.Err("ERROR : " + line)
+	l.SyslogWriter.Err("ERROR: " + line)
 }
 
 type Log struct {

--- a/slapdns/slapdns.go
+++ b/slapdns/slapdns.go
@@ -269,7 +269,7 @@ func rndc(op, zone_name, output_path string) error {
 	}
 
 	if conf.Limit_rndc == false {
-		if e := exec.Command(cmd, args...).Run(); e != nil {
+		if err := exec.Command(cmd, args...).Run(); err != nil {
 			return err
 		}
 		if op == "delzone" {


### PR DESCRIPTION
- This ensures that rndc errors are correctly trapped when rndc rate limiting is off
- It also fixes a small bug in the syslog writter that made error logs look stupid

fixes #40
fixes #38